### PR TITLE
Add a Livewire version of the component

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -11,7 +11,6 @@ class ServiceProvider extends LaravelServiceProvider
     {
         $this->loadViewsFrom(__DIR__ . '/resources/views', 'mermaid');
 
-        
         $this->publishes([
             __DIR__ . '/../config/mermaid.php' => config_path('mermaid.php'),
         ], 'config');

--- a/src/resources/views/components/livewire-component.blade.php
+++ b/src/resources/views/components/livewire-component.blade.php
@@ -1,0 +1,29 @@
+<div x-data="mermaid">
+    <div wire:ignore x-ref="target" class="{{ $class ?? '' }}"></div>
+</div>
+
+@assets
+    <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
+@endassets
+
+@script
+<script>
+    Alpine.data('mermaid', () => ({
+        init() {
+            mermaid.initialize({
+                startOnLoad: false,
+            });
+
+            this.$watch('$wire.{{ $attributes->wire('model')->value() }}', () => {
+                this.render();
+            });
+
+            this.render();
+        },
+        async render() {
+            const { svg } = await mermaid.render('graph-{{ $this->id() }}', this.$wire.{{ $attributes->wire('model')->value() }});
+            this.$refs.target.innerHTML = svg;
+        }
+    }));
+</script>
+@endscript


### PR DESCRIPTION
This PR adds a Livewire compatible version that will re-render the diagram when a property on the Livewire component is updated.

Here's an example of using this in a Livewire component where when you increase the limit, more users will be loaded and added to the diagram.

Class:
```php
<?php

namespace App\Livewire;

use App\Models\User;
use Livewire\Component;

class Mermaid extends Component
{
    public $limit = 2;

    public $mermaid;

    public function render()
    {
        $this->mermaid = app('mermaid')->generateDiagramFromCollection(
            User::with('posts')->limit($this->limit)->get()
        );

        return view('livewire.mermaid');
    }
}
```

View:
```blade
<div>
    <x-mermaid::livewire-component wire:model="mermaid" />

    <div>
        <label for="limit">Limit:</label>
        <input wire:model.live="limit" id="limit" type="number">
    </div>
</div>
```