### PR TITLE
Accessing name attribute directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Laravel and php provide a lot of helpers and convinience methods for working wit
 
 ```php
 // In your controller
+use IcehouseVentures\LaravelMermaid\Facades\Mermaid;
+
 public function index()
 {
     $data = [
@@ -98,7 +100,7 @@ public function index()
         'C-->D'
     ];
 
-    app('mermaid')->generateDiagramFromArray($data);
+    Mermaid::build()->generateDiagramFromArray($data);
 
     return view('your-view', compact('data'));
 }
@@ -121,11 +123,13 @@ You can also pass in an Eloquent collection to the Blade component. This allows 
 
 ```php
 // In your controller
+use IcehouseVentures\LaravelMermaid\Facades\Mermaid;
+
 public function index()
 {
     $collection = User::with('posts')->get();
     
-    $data = app('mermaid')->generateDiagramFromCollection($collection);
+    $data = Mermaid::build()->generateDiagramFromCollection($collection);
     
     return view('your-view', compact('data'));
 }
@@ -152,6 +156,8 @@ You can also pass in custom collections, models and relationships to the Blade c
 
 
 ```php
+use IcehouseVentures\LaravelMermaid\Facades\Mermaid;
+
 $users = User::with('posts')->take(3)->get();
 
 $data = [];
@@ -171,7 +177,7 @@ $data[] = "class U1,U2 user";
 $data[] = "class P1,P2,P3 post";
 $data[] = "linkStyle default stroke:#94a3b8,stroke-width:4px";
 
-$data = app('mermaid')->generateDiagramFromArray($data);
+$data = Mermaid::build()->generateDiagramFromArray($data);
 ```
 
 ```mermaid
@@ -225,6 +231,7 @@ namespace App\Livewire;
 
 use App\Models\User;
 use Livewire\Component;
+use IcehouseVentures\LaravelMermaid\Facades\Mermaid;
 
 class Mermaid extends Component
 {
@@ -234,7 +241,7 @@ class Mermaid extends Component
 
     public function render()
     {
-        $this->mermaid = app('mermaid')->generateDiagramFromCollection(
+        $this->mermaid = Mermaid::build()->generateDiagramFromCollection(
             User::with('posts')->limit($this->limit)->get()
         );
 

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,10 @@
         "laravel": {
             "providers": [
                 "IcehouseVentures\\LaravelMermaid\\ServiceProvider"
-            ]
+            ],
+            "aliases": {
+                "Chartjs": "IcehouseVentures\\LaravelMermaid\\Facades\\Mermaid"
+            }
         }
     }
 }

--- a/src/Facades/Mermaid.php
+++ b/src/Facades/Mermaid.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace IcehouseVentures\LaravelMermaid\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+class Mermaid extends Facade
+{
+    protected static function getFacadeAccessor()
+    {
+        return 'mermaid';
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -21,7 +21,13 @@ class ServiceProvider extends LaravelServiceProvider
     {
         $this->mergeConfigFrom(__DIR__ . '/../config/mermaid.php', 'mermaid');
 
+        // @note This is an old interface allowing usage via `app('mermaid')->generateDiagramFromCollection();`
         $this->app->bind('mermaid', function () {
+            return new Builder();
+        });
+
+        // @note This new interface allows usage via facade `IcehouseVentures\LaravelMermaid\Facades\Mermaid::build()->generateDiagramFromArray();`
+        $this->app->singleton('mermaid', function() {
             return new Builder();
         });
     }

--- a/src/Support/Builder.php
+++ b/src/Support/Builder.php
@@ -86,7 +86,7 @@ class Builder
 
             $className = class_basename($model);
             $key = $model->getKey();
-            $modelLabel = $label ? $model->{$label} : $model->getNameAttribute() ?? $className.' '.$key;
+            $modelLabel = $label ? $model->{$label} : $model->name ?? $className.' '.$key;
 
             // Object node
             $lines[] = "{$className}{$key}[$modelLabel];\n";
@@ -102,7 +102,7 @@ class Builder
                 // hasOne or belongsTo or morphOne
                 if ($relation instanceof Model) {
                     $relatedKey = $relation->getKey();
-                    $relatedLabel = $label ? $relation->{$label} : $relation->getNameAttribute() ?? $relation->getKey();
+                    $relatedLabel = $label ? $relation->{$label} : $relation->name ?? $relation->getKey();
                     $relatedClassName = class_basename($relation);
 
                     $lines[] = "{$relatedClassName}{$relatedKey}[$relatedLabel];\n";

--- a/src/Support/Builder.php
+++ b/src/Support/Builder.php
@@ -8,8 +8,17 @@ use Illuminate\Support\Str;
 
 class Builder
 {
+    /**
+     * @return Builder
+     */
+    public function build() {
+        return new self();
+    }
 
-    // Entry point for generating a diagram from an array
+    /**
+     * Generate a diagram from a PHP array
+     * @return string
+     */
     public static function generateDiagramFromArray(array $data, ?string $type = null, ?array $options = []): string
     {
         $diagram = self::formatArrayToLines($data);
@@ -18,19 +27,29 @@ class Builder
         return $diagram;
     }
 
-    // Format the array to lines to match markdown and mermaid format
+    /**
+     * Format an array into lines
+     * @return string
+     */
     protected static function formatArrayToLines(array $data): string
     {
         return Collection::make($data)->map(fn($item) => "$item;\n")->join('');
     }
 
     // Set the diagram type to the mermaid diagram type
+    /**
+     * Set the Mermaid diagram type ('graph LR', 'graph TD' etc)
+     * @return string
+     */
     protected static function setDiagramType(?string $type): string
     {
         return ($type ?? "graph LR") . ";\n";
     }
 
-    // Set the theme for the diagram
+    /**
+     * Set the diagram theme
+     * @return string
+     */
     public static function setTheme(?string $theme = null): ?string
     {
         if (empty($theme)) {
@@ -67,7 +86,10 @@ class Builder
         return $themeString;
     }
 
-    // Entry point for generating a diagram from a collection of models
+    /**
+     * Generate a diagram from a Collection of models
+     * @return string
+     */
     public static function generateDiagramFromCollection(Collection $models, ?string $label = null, ?string $type = null, ?array $options = []): string
     {
         $diagram = self::formatCollectionToLines($models, $label);
@@ -77,7 +99,10 @@ class Builder
         return $diagram;
     }
 
-    // Format the eloquent models into lines to match the mermaid data format
+    /**
+     * Iterate the Eloquent models and convert to Mermaid lines
+     * @return string
+     */
     protected static function formatCollectionToLines(Collection $models, ?string $label = null, $parentModel = null): string
     {
         $lines = [];


### PR DESCRIPTION
Included changes are to:
- use new facade interface
```
use IcehouseVentures\LaravelMermaid\Facades\Mermaid;
Mermaid::build()->generateDiagramFromArray($data);
```
- access the `name` attribute directly instead of using `getNameAttribute()` when generating from a collection

See [new demo repository](https://github.com/frontier-sh/laravel-mermaid-demo) for detailed examples.